### PR TITLE
Dep vers

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -128,7 +128,7 @@ hooks:
     #now that we've extracted the contents of the image, we need to figure out the name of the directory we're dealing 
     #with. still.basic is always the latest version of LibreOffice so that means the extracted directory name can change
     #as the version number changes.
-    maybeLOdir=$(find . -type d -name "libreoffice*");
+    maybeLOdir=$(find . -type d -name "libreoffice*.*" -maxdepth 3);
     printf "What I found for maybeLOdir is : %s\n" "${maybeLOdir}"
     if [ -z "${maybeLOdir}" ]; then
       echo "I was unable to find the latest libreoffice directory in the extracted contents.";
@@ -183,8 +183,8 @@ hooks:
     cd "${PLATFORM_CACHE_DIR}/chromium" 
       
     bash "${PLATFORM_CACHE_DIR}/chromium/update.sh"
-    printf "contents of %s:" "${PLATFORM_CACHE_DIR}/chromium"
-    ls -al "${PLATFORM_CACHE_DIR}/chromium"
+    #printf "contents of %s:" "${PLATFORM_CACHE_DIR}/chromium"
+    #ls -al "${PLATFORM_CACHE_DIR}/chromium"
     #now we need to copy the contents of the symlink "latest" over into the app directory
     mkdir -p "${PLATFORM_APP_DIR}/.global/bin/chromium"
     cp -Rvf "${PLATFORM_CACHE_DIR}/chromium/latest/." "${PLATFORM_APP_DIR}/.global/bin/chromium"  

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -129,14 +129,17 @@ hooks:
     #with. still.basic is always the latest version of LibreOffice so that means the extracted directory name can change
     #as the version number changes.
     maybeLOdir=$(find . -type d -name "libreoffice*");
-    if [[ -z "${maybeLOdir}" ]]; then
+    printf "What I found for maybeLOdir is : %s\n" "${maybeLOdir}"
+    if [ -z "${maybeLOdir}" ]; then
       echo "I was unable to find the latest libreoffice directory in the extracted contents.";
       exit 1;
     else 
       libreOfficeDir=$(basename "${maybeLOdir}")
     fi
+    
+    printf "libreOfficeDir is now : %s \n" "${libreOfficeDir}"
 
-    # now copy the contents of squashfs-root/opt/"$libreOfficeDir".3/program/ to /app/.libreoffice/bin/
+    # now copy the contents of squashfs-root/opt/"$libreOfficeDir"/program/ to /app/.libreoffice/bin/
     echo "Copying libreoffice files to ${PLATFORM_APP_DIR}/.libreoffice/bin... Files copied: "
     # @todo, the libreoffice directory name can and WILL Change as the version changes. We need to either designate a
     # specic version, and then allow for a manged upgrade, or check the name of the directory after we run the 
@@ -167,8 +170,8 @@ hooks:
     
     #make sure we have a bin in .global
     mkdir -p "${PLATFORM_APP_DIR}/.global/bin"
-    cp -Rvf "${PLATFORM_CACHE_DIR}/Image-ExifTool-12.47/lib" "${PLATFORM_APP_DIR}/.global/bin"
-    cp -vf "${PLATFORM_CACHE_DIR}/Image-ExifTool-12.47/exiftool" "${PLATFORM_APP_DIR}/.global/bin"
+    cp -Rvf "${PLATFORM_CACHE_DIR}/Image-ExifTool-${exifVersion}/lib" "${PLATFORM_APP_DIR}/.global/bin"
+    cp -vf "${PLATFORM_CACHE_DIR}/Image-ExifTool-${exifVersion}/exiftool" "${PLATFORM_APP_DIR}/.global/bin"
    
     #now Chromium!
     if [ ! -d "${PLATFORM_CACHE_DIR}/chromium" ] || [ ! -d "${PLATFORM_CACHE_DIR}/chromium/.git"  ]; then

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -82,7 +82,7 @@ disk: 7168
 hooks:
   build: |
     set -e
-      
+    exifVersion="12.47"  
     bash install-redis.sh 5.3.7
 
     # This is needed for the installer in the deploy hook.
@@ -124,13 +124,24 @@ hooks:
       #now let's delete the AppImage to free up some space
       rm LibreOffice-still.basic-x86_64.AppImage
     fi
-      
-    # now copy the contents of squashfs-root/opt/libreoffice7.3/program/ to /app/.libreoffice/bin/
+     
+    #now that we've extracted the contents of the image, we need to figure out the name of the directory we're dealing 
+    #with. still.basic is always the latest version of LibreOffice so that means the extracted directory name can change
+    #as the version number changes.
+    maybeLOdir=$(find . -type d -name "libreoffice*");
+    if [[ -z "${maybeLOdir}" ]]; then
+      echo "I was unable to find the latest libreoffice directory in the extracted contents.";
+      exit 1;
+    else 
+      libreOfficeDir=$(basename "${maybeLOdir}")
+    fi
+
+    # now copy the contents of squashfs-root/opt/"$libreOfficeDir".3/program/ to /app/.libreoffice/bin/
     echo "Copying libreoffice files to ${PLATFORM_APP_DIR}/.libreoffice/bin... Files copied: "
     # @todo, the libreoffice directory name can and WILL Change as the version changes. We need to either designate a
     # specic version, and then allow for a manged upgrade, or check the name of the directory after we run the 
     # --appimage-extract command to find out the name of the directory we're working with.
-    cp -Rvf ./squashfs-root/opt/libreoffice7.3/program/* "${PLATFORM_APP_DIR}/.libreoffice/bin/" | wc -l
+    cp -Rvf ./squashfs-root/opt/${libreOfficeDir}/program/* "${PLATFORM_APP_DIR}/.libreoffice/bin/" | wc -l
       
     #add our libreoffice path to PATH
     echo 'export PATH="'$PLATFORM_APP_DIR'/.libreoffice/bin${PATH+:$PATH}";' >> "${PLATFORM_APP_DIR}/.environment"
@@ -143,13 +154,14 @@ hooks:
     cp -vf "${PLATFORM_CACHE_DIR}/facedetect" "${PLATFORM_APP_DIR}/.libreoffice/bin/facedetect"
 
     #next is exiftool
-    if [ ! -d "${PLATFORM_CACHE_DIR}/Image-ExifTool-12.47" ]; then
-      wget -P "${PLATFORM_CACHE_DIR}" https://exiftool.org/Image-ExifTool-12.47.tar.gz
+    if [ ! -d "${PLATFORM_CACHE_DIR}/Image-ExifTool-${exifVersion}" ]; then
+      echo "retrieving https://exiftool.org/Image-ExifTool-${exifVersion}.tar.gz"
+      wget -P "${PLATFORM_CACHE_DIR}" https://exiftool.org/Image-ExifTool-${exifVersion}.tar.gz
       cd "${PLATFORM_CACHE_DIR}"
-      tar -xvf Image-ExifTool-12.47.tar.gz
+      tar -xvf Image-ExifTool-${exifVersion}.tar.gz
       # get rid of the archive since we've cached the contents
-      rm "${PLATFORM_CACHE_DIR}/Image-ExifTool-12.47.tar.gz"
-      cd "${PLATFORM_CACHE_DIR}/Image-ExifTool-12.47/"
+      rm "${PLATFORM_CACHE_DIR}/Image-ExifTool-${exifVersion}.tar.gz"
+      cd "${PLATFORM_CACHE_DIR}/Image-ExifTool-${exifVersion}/"
       perl Makefile.PL
     fi
     


### PR DESCRIPTION
- Changes build script to accommodate changing libreoffice directory name after extracting contents from LibreOffice AppImage. 
- Adds ability to designate which version of ExifTools to install
- Removes echo statements that are no longer needed