### PR TITLE
Opcache perf

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,16 +40,16 @@ runtime:
 variables:
   php:
     memory_limit: 128M
-      opcache.enable: 1 # enables the Opcache for PHP server
-      opcache.enable_cli: 1 # enables the Opcache for CLI mode
-      opcache.jit_buffer_size: 256M # JIT buffer memory size. 0 value disables the JIT compiler.
-      opcache.max_accelerated_files: 20000 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
-      opcache.memory_consumption: 256 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
-      opcache.validate_timestamps: 0 # https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
-      #opcache.preload: /app/config/preload.php #https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
-      #opcache.preload_user: web # https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
-      realpath_cache_size: 4096K # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
-      realpath_cache_ttl: 600 # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
+    opcache.enable: 1 # enables the Opcache for PHP server
+    opcache.enable_cli: 1 # enables the Opcache for CLI mode
+    opcache.jit_buffer_size: 256M # JIT buffer memory size. 0 value disables the JIT compiler.
+    opcache.max_accelerated_files: 20000 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
+    opcache.memory_consumption: 256 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
+    opcache.validate_timestamps: 0 # https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
+    #opcache.preload: /app/config/preload.php #https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
+    #opcache.preload_user: web # https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
+    realpath_cache_size: 4096K # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
+    realpath_cache_ttl: 600 # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
 
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,6 +40,9 @@ runtime:
 variables:
   php:
       memory_limit: 128M
+      opcache.enable: 1 # enables the Opcache for PHP server
+      opcache.enable_cli: 1 # enables the Opcache for CLI mode
+      opcache.jit_buffer_size: 256M # JIT buffer memory size. 0 value disables the JIT compiler.
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -39,10 +39,18 @@ runtime:
 
 variables:
   php:
-      memory_limit: 128M
+    memory_limit: 128M
       opcache.enable: 1 # enables the Opcache for PHP server
       opcache.enable_cli: 1 # enables the Opcache for CLI mode
       opcache.jit_buffer_size: 256M # JIT buffer memory size. 0 value disables the JIT compiler.
+      opcache.max_accelerated_files: 20000 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
+      opcache.memory_consumption: 256 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
+      opcache.validate_timestamps: 0 # https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
+      #opcache.preload: /app/config/preload.php #https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
+      #opcache.preload_user: web # https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
+      realpath_cache_size: 4096K # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
+      realpath_cache_ttl: 600 # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
+
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:


### PR DESCRIPTION
- Enables opcache and jit
- adds the following to php.ini
  -       opcache.max_accelerated_files: 20000 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
  -       opcache.memory_consumption: 256 # https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance
  -       opcache.validate_timestamps: 0 # https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
  -       realpath_cache_size: 4096K # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache
  -       realpath_cache_ttl: 600 # https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache

Some things to consider:
[According to our docs](https://docs.platform.sh/languages/php/ini.html#default-phpini-settings), `opcache.validate_timestamps` is set to `On`. I have it set to `Off` in this PR but am not familiar enough with Pimcore to know  if it should be off or left to on per our docs. but [we also state ](https://docs.platform.sh/languages/php/tuning.html#configure-opcache)you can turn it off. 

I have `opcache.preload` commented out for now since it's generating the preload.php file in `var/cache/dev` in every environment regardless of which environment it really is. My assumption is it is being set in .env and we'll need to alter it to look at `$PLATFORM_ENVIRONMENT_TYPE`. 