### PR TITLE
Enhance/im pdf2img

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -145,7 +145,9 @@ hooks:
       # image hasnt been extracted. do we even have the image?
       if [ ! -f LibreOffice-still.basic-x86_64.AppImage ]; then
         echo "downloading LibreOffice appimage" 
-        wget https://appimage.sys42.eu/LibreOffice-still.basic-x86_64.AppImage
+        # @todo this location has a tendency to change. This should be an environmental variable that can be changed
+        # without having to update code
+        wget https://appimages.libreitalia.org/LibreOffice-still.basic-x86_64.AppImage
       fi
      
       # make sure we can execute it 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -251,12 +251,18 @@ hooks:
     # make sure we have a directory in the app location
     echo "Creating imagick directory in app directory..."
     mkdir -p "${PLATFORM_APP_DIR}/.imagick/bin"
-    mkdir -p "${PLATFORM_APP_DIR}/.imagick/lib"  
+    mkdir -p "${PLATFORM_APP_DIR}/.imagick/lib"
+    # ImageMagick wants its config files in certain locations so we'll copy them over
+    mkdir -p "${PLATFORM_APP_DIR}/.config/ImageMagick"  
       
     #now copy our files from squashfs-root/usr/bin/ to 
     printf "Copying imagick files from %s to %s... \n" "${PLATFORM_CACHE_DIR}/magick/squashfs-root/usr/" "${PLATFORM_APP_DIR}/.imagick/"
     cp -Rvf ./squashfs-root/usr/bin/* "${PLATFORM_APP_DIR}/.imagick/bin"
     cp -Rvf ./squashfs-root/usr/lib/* "${PLATFORM_APP_DIR}/.imagick/lib"
+    #And copy the configuration files from squashfs-root/etc/ImageMagick-7/ to /app/.config/ImageMagick
+    printf "Copying imagick configuration files from %s to %s... \n" "${PLATFORM_CACHE_DIR}/magick/squashfs-root/etc/ImageMagick-7" "${PLATFORM_APP_DIR}/.config/ImageMagick"
+    cp -Rvf ./squashfs-root/etc/ImageMagick-7/* "${PLATFORM_APP_DIR}/.config/ImageMagick"
+      
     #last add PATH to PATH
     echo "Adding imagick bin path to PATH"  
     echo 'export PATH="'$PLATFORM_APP_DIR'/.imagick/bin/${PATH+:$PATH}";' >> "${PLATFORM_APP_DIR}/.environment"

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -116,7 +116,7 @@ disk: 7168
 hooks:
   build: |
     set -e
-    exifVersion="12.47"  
+    exifVersion="12.60"  
     bash install-redis.sh 5.3.7
 
     # This is needed for the installer in the deploy hook.
@@ -262,8 +262,8 @@ hooks:
     cp -Rvf ./squashfs-root/usr/bin/* "${PLATFORM_APP_DIR}/.imagick/bin"
     cp -Rvf ./squashfs-root/usr/lib/* "${PLATFORM_APP_DIR}/.imagick/lib"
     #And copy the configuration files from squashfs-root/etc/ImageMagick-7/ to /app/.config/ImageMagick
-    printf "Copying imagick configuration files from %s to %s... \n" "${PLATFORM_CACHE_DIR}/magick/squashfs-root/etc/ImageMagick-7" "${PLATFORM_APP_DIR}/.config/ImageMagick"
-    cp -Rvf ./squashfs-root/etc/ImageMagick-7/* "${PLATFORM_APP_DIR}/.config/ImageMagick"
+    printf "Copying imagick configuration files from %s to %s... \n" "${PLATFORM_CACHE_DIR}/magick/squashfs-root/usr/etc/ImageMagick-7" "${PLATFORM_APP_DIR}/.config/ImageMagick"
+    cp -Rvf ./squashfs-root/usr/etc/ImageMagick-7/* "${PLATFORM_APP_DIR}/.config/ImageMagick"
       
     #last add PATH to PATH
     echo "Adding imagick bin path to PATH"  


### PR DESCRIPTION
This started off as an update to ImageMagick to fix some things (see below), but then discovered other issues.

re: ImageMagick, previously we weren't copying over any of the [configuration files](https://imagemagick.org/script/resources.php) that come in the AppImage. Until recently, we hadn't come across any use cases where it needed them, but recently someone needed to convert from a pdf back to an image, and in that case ImageMagick needed the [delegates.xml](https://imagemagick.org/source/delegates.xml) file. Supposedly, we could add a configuration file location via the `$MAGICK_CONFIGURE_PATH` environmental variable but all efforts to use it failed. However, ImageMagick does check the `$HOME/.config/ImageMagick` location. With that knowledge, we now copy over the default set of config files from the AppImage extraction to the previously mentioned location.

When testing the above, I discovered that the domain that was previously in use (sys42.eu) for the LibreOffice AppImage download has expired and no longer valid. Current technical contact is listed as https://business.aruba.it/home.aspx.  The new domain is ibreitalia.org. Hopefully this does not change again.

Also discovered that the download for 12.47 of the ExifTool is no longer available. Updated the version we're retrieving to 12.60 which is listed as the current stable version as of this posting.